### PR TITLE
Bump ajv and less

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "d3": "^3.5.7",
     "eventemitter3": "^1.1.1",
     "express": "^4.13.3",
-    "less": "^2.5.3",
+    "less": "^2.7.3",
     "less-loader": "^2.0.0",
     "lodash": "^4.17.10",
     "normalize.css": "^3.0.3",


### PR DESCRIPTION
Bumps [ajv](https://github.com/ajv-validator/ajv) to 6.12.6 and updates ancestor dependency [less](https://github.com/less/less.js). These dependencies need to be updated together.


Updates `ajv` from 4.11.8 to 6.12.6
- [Release notes](https://github.com/ajv-validator/ajv/releases)
- [Commits](https://github.com/ajv-validator/ajv/compare/4.11.8...v6.12.6)

Updates `less` from 2.7.3 to 2.7.3
- [Release notes](https://github.com/less/less.js/releases)
- [Changelog](https://github.com/less/less.js/blob/master/CHANGELOG.md)
- [Commits](https://github.com/less/less.js/compare/v2.7.3...v2.7.3)

---
updated-dependencies:
- dependency-name: ajv dependency-type: indirect
- dependency-name: less dependency-type: direct:production ...